### PR TITLE
Dont strip extra chars from bom css

### DIFF
--- a/lib/asset_bom_removal/bom_remover.rb
+++ b/lib/asset_bom_removal/bom_remover.rb
@@ -1,0 +1,12 @@
+module AssetBomRemoval
+  module BomRemover
+    def remove_bom(css_string)
+      if css_string.bytes[0..2] == [0xEF, 0xBB, 0xBF]
+        css_string[3..-1]
+      else
+        css_string
+      end
+    end
+    module_function :remove_bom
+  end
+end

--- a/lib/asset_bom_removal/bom_remover.rb
+++ b/lib/asset_bom_removal/bom_remover.rb
@@ -1,12 +1,40 @@
 module AssetBomRemoval
-  module BomRemover
-    def remove_bom(css_string)
-      if css_string.bytes[0..2] == [0xEF, 0xBB, 0xBF]
-        css_string.force_encoding('UTF-8')[1..-1]
+  class BomRemover
+    def self.remove_bom(string)
+      new(string).remove_bom
+    end
+
+    def initialize(string)
+      @string = string
+    end
+
+    def remove_bom
+      if string_starts_with_utf8_bom?
+        string.dup.force_encoding('UTF-8').tap do |utf8_string|
+          utf8_string.slice!(0)
+        end
       else
-        css_string
+        string
       end
     end
-    module_function :remove_bom
+
+  private
+
+    attr_reader :string
+
+    def string_starts_with_utf8_bom?
+      with_encoding('UTF-8') do |utf8_string|
+        utf8_string[0] == "\xEF\xBB\xBF"
+      end
+    end
+
+    def with_encoding(encoding)
+      old_encoding = string.encoding
+      begin
+        return (yield string.force_encoding(encoding))
+      ensure
+        string.force_encoding(old_encoding)
+      end
+    end
   end
 end

--- a/lib/asset_bom_removal/bom_remover.rb
+++ b/lib/asset_bom_removal/bom_remover.rb
@@ -2,7 +2,7 @@ module AssetBomRemoval
   module BomRemover
     def remove_bom(css_string)
       if css_string.bytes[0..2] == [0xEF, 0xBB, 0xBF]
-        css_string[3..-1]
+        css_string.force_encoding('UTF-8')[1..-1]
       else
         css_string
       end

--- a/lib/asset_bom_removal/sass_no_bom_compressor.rb
+++ b/lib/asset_bom_removal/sass_no_bom_compressor.rb
@@ -4,17 +4,7 @@ module AssetBomRemoval
   class SassNoBomCompressor < Sprockets::SassCompressor
     # Let the default sass processor do all the hard work
     def call(input)
-      remove_bom_from_css(super(input))
-    end
-
-  private
-
-    def remove_bom_from_css(css_string)
-      if css_string.bytes[0..2] == [0xEF, 0xBB, 0xBF]
-        css_string[3..-1]
-      else
-        css_string
-      end
+      BomRemover.remove_bom(super(input))
     end
   end
 end

--- a/spec/asset_bom_removal/bom_remover_spec.rb
+++ b/spec/asset_bom_removal/bom_remover_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+require 'asset_bom_removal/bom_remover'
+
+RSpec.describe AssetBomRemoval::BomRemover do
+  subject { described_class }
+
+  let(:bom) { "\xEF\xBB\xBF" }
+
+  shared_examples "removing the BOM from the string" do
+    let(:stripped_string) { subject.remove_bom(example_string_with_bom) }
+
+    it 'removes the BOM from the string' do
+      expect(stripped_string.bytes[0..3]).not_to eq bom.bytes
+    end
+  end
+
+  context 'for a utf-8 string with the bom and ascii characters' do
+    let(:example_string_with_bom) { "#{bom}hello" }
+    let(:example_string_without_bom) { "hello" }
+
+    include_examples "removing the BOM from the string"
+  end
+
+  context 'for a utf-8 string with the bom and utf-8 characters' do
+    let(:example_string_with_bom) { "#{bom}Ⓗ∈llo" }
+    let(:example_string_without_bom) { "Ⓗ∈llo" }
+
+    include_examples "removing the BOM from the string"
+  end
+
+  context 'for an ascii string with the bom and ascii characters' do
+    # this lets us test for strange encoding quirks
+    let(:example_string_with_bom) { "#{bom}hello".force_encoding('ascii-8bit') }
+    let(:example_string_without_bom) { "hello" }
+
+    include_examples "removing the BOM from the string"
+  end
+
+  context 'for an ascii string with the bom and utf-8 characters' do
+    # this lets us test for strange encoding quirks
+    let(:example_string_with_bom) { "#{bom}Ⓗ∈llo".force_encoding('ascii-8bit') }
+    let(:example_string_without_bom) { "Ⓗ∈llo" }
+
+    include_examples "removing the BOM from the string"
+  end
+
+  shared_examples "leaving an un-BOM-ified string alone" do
+    let(:stripped_string) { subject.remove_bom(example_string_without_bom) }
+
+    it 'leaves the string alone' do
+      expect(stripped_string.bytes).to eq example_string_without_bom.bytes
+    end
+
+    it 'returns the string encoded as it was' do
+      expect(stripped_string.encoding).to eq example_string_without_bom.encoding
+    end
+  end
+
+  context 'for a utf-8 string without the bom and ascii characters' do
+    let(:example_string_without_bom) { "hello" }
+
+    include_examples "leaving an un-BOM-ified string alone"
+  end
+
+  context 'for a utf-8 string without the bom and utf-8 characters' do
+    let(:example_string_without_bom) { "Ⓗ∈llo" }
+
+    include_examples "leaving an un-BOM-ified string alone"
+  end
+
+  context 'for an ascii string without the bom and ascii characters' do
+    # this lets us test for strange encoding quirks
+    let(:example_string_without_bom) { "hello".force_encoding('ascii-8bit') }
+
+    include_examples "leaving an un-BOM-ified string alone"
+  end
+
+  context 'for an ascii string without the bom and utf-8 characters' do
+    # this lets us test for strange encoding quirks
+    let(:example_string_without_bom) { "Ⓗ∈llo".force_encoding('ascii-8bit') }
+
+    include_examples "leaving an un-BOM-ified string alone"
+  end
+end

--- a/spec/asset_bom_removal/bom_remover_spec.rb
+++ b/spec/asset_bom_removal/bom_remover_spec.rb
@@ -12,6 +12,14 @@ RSpec.describe AssetBomRemoval::BomRemover do
     it 'removes the BOM from the string' do
       expect(stripped_string.bytes[0..3]).not_to eq bom.bytes
     end
+
+    it 'otherwise leaves the string alone' do
+      expect(stripped_string.bytes).to eq example_string_without_bom.bytes
+    end
+
+    it 'returns the string encoded as utf-8' do
+      expect(stripped_string.encoding).to eq Encoding::UTF_8
+    end
   end
 
   context 'for a utf-8 string with the bom and ascii characters' do

--- a/spec/asset_bom_removal/sass_no_bom_compressor_spec.rb
+++ b/spec/asset_bom_removal/sass_no_bom_compressor_spec.rb
@@ -19,6 +19,15 @@ RSpec.describe AssetBomRemoval::SassNoBomCompressor do
         no_bom_version = subject.call(input)
         expect(no_bom_version.bytes.take(3)).not_to eq(bom_bytes)
       end
+
+      it 'leaves the CSS otherwise untouched' do
+        default_version = sass_compressor.call(input)
+        # confirm our expectations that the sass compressor will generate a BOM
+        expect(default_version.bytes.take(3)).to eq(bom_bytes)
+
+        no_bom_version = subject.call(input)
+        expect(no_bom_version.bytes).to eq(default_version.bytes[3..-1])
+      end
     end
 
     context 'when supplied with css that does not generate a BOM' do


### PR DESCRIPTION
For: https://trello.com/c/UcJJBH0k/183-investigate-bom-issue-with-asset-compilation 
and: https://trello.com/c/oFhtO0Gm/146-enable-subresource-integrity-sri-on-government-frontend-l

When we deployed a version of government-frontend to production with this gem and SRI enabled (see: https://github.com/alphagov/government-frontend/pull/400) we noticed that the BOM was removed from our CSS that had it, but we had also removed 2 other characters from the start of the file.  We reverted the deploy (see: https://github.com/alphagov/government-frontend/pull/401) and investigated.

Turns out we were mixing up the abstraction levels we were working with the string at.  We checked the first 3 bytes, but then stripped the first 3 characters.  IF the string was ASCII this would be the same thing, but most likely it's UTF-8 and this isn't necessarily the same thing, and in our case definitely not the right thing.  The 3-byte BOM represents a single character in a UTF-8 string, so we only need to strip 1 character from the string (if it is UTF-8).

In this PR we fix that bug, and make sure we are more robust in the face of potential encoding problems by making sure we always work with UTF-8 strings when checking for or removing the BOM.