### PR TITLE
Explicitly require BomRemover in SassNoBomCompressor

### DIFF
--- a/lib/asset_bom_removal/sass_no_bom_compressor.rb
+++ b/lib/asset_bom_removal/sass_no_bom_compressor.rb
@@ -1,4 +1,5 @@
 require 'sprockets/sass_compressor'
+require 'asset_bom_removal/bom_remover'
 
 module AssetBomRemoval
   class SassNoBomCompressor < Sprockets::SassCompressor


### PR DESCRIPTION
The specs all pass, but it fails when used in an app in production mode
with:

    NameError: uninitialized constant AssetBomRemoval::SassNoBomCompressor::BomRemover

(As seen https://github.com/alphagov/government-frontend/pull/408#pullrequestreview-52021781)
Suspect this is because we get rails autoloading for free in test or
development mode, but not so much in production.  Adding an explicit
require gets round this.